### PR TITLE
Removing unsupported date filters for API calls

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,11 +78,11 @@ function Stop(stop, map) {
 }
 
 function shapes_url() {
-  return ENV.V3_API_URL + "/shapes?filter[route]=" + shape_route() + "&include=stops&api_key=" + ENV.MBTA_API_KEY + get_date_filter();
+  return ENV.V3_API_URL + "/shapes?filter[route]=" + shape_route() + "&include=stops&api_key=" + ENV.MBTA_API_KEY;
 }
 
 function vehicles_url() {
-  return ENV.V3_API_URL + "/vehicles?filter[route]=" + vehicle_route() + "&include=route,stop&api_key=" + ENV.MBTA_API_KEY + get_date_filter();
+  return ENV.V3_API_URL + "/vehicles?filter[route]=" + vehicle_route() + "&include=route,stop&api_key=" + ENV.MBTA_API_KEY;
 }
 
 function vehicle_route() {


### PR DESCRIPTION
Ticket: [Return an error code if someone uses a wrong filter](https://app.asana.com/0/810933294009540/1104657015105420)

See discussion in https://github.com/mbta/api/pull/11 for the context. 

Basically `/shapes` and `/vehicles` endpoints don't support filtering by date. Those filters were simply ignored before but going to return error once https://github.com/mbta/api/pull/11 is merged. 