### PR TITLE
New route_id for Braintree shuttles

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,7 +86,7 @@ function vehicles_url() {
 }
 
 function vehicle_route() {
-  return "Shuttle002,Shuttle005";
+  return "Shuttle-BraintreeNorthQuincy,Shuttle005";
 }
 
 function shape_route() {


### PR DESCRIPTION
Several weeks ago, GTFS changed the `route_id` for North Quincy - Braintree bus shuttles in https://github.com/mbta/gtfs_creator/pull/436, from `Shuttle002` to `Shuttle-BraintreeNorthQuincy`, to make it more consistent with other routes, and as it was not being used currently.

This was never updated on `shuttle-tracker`, however, which has routes hard-coded, meaning on weekends/weeknights with disruptions all the way to Braintree, the shuttle map https://cdn.mbtace.com/shuttle-tracker/ was not showing the proper route. Even though Wollaston is opening soon, it's probably worth fixing the issue in case we have to run this shuttle again soon.